### PR TITLE
fix(webpack): fixed the copying of the icons

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,10 @@ const config = {
         }),
         new CopyPlugin({
             patterns: [
-                {from: "./node_modules/web-tree-sitter/tree-sitter.wasm", to: distDir},
+                {
+                    from: "./node_modules/web-tree-sitter/tree-sitter.wasm",
+                    to: distDir,
+                },
                 {
                     from: "./server/src/languages/tolk/stubs/stubs.tolk",
                     to: path.join(distDir, "stubs"),
@@ -77,21 +80,22 @@ const config = {
                     from: "./server/src/languages/tlb/tree-sitter-tlb/tree-sitter-tlb.wasm",
                     to: distDir,
                 },
-                {from: "./client/src/assets/icons/ton-icon.svg", to: path.join(distDir, "icons")},
                 {
-                    from: "./client/src/assets/icons/icon-tlb-dark.svg",
-                    to: path.join(distDir, "icons"),
-                },
-                {
-                    from: "./client/src/assets/icons/icon-boc-dark.svg",
-                    to: path.join(distDir, "icons"),
+                    from: "./client/src/assets/icons/*",
+                    to: path.join(distDir, "icons", "[name][ext]"),
                 },
                 {
                     from: "server/src/languages/fift/asm/asm.json",
                     to: distDir,
                 },
-                {from: "./package.server.json", to: path.join(distDir, "package.json")},
-                {from: "./README.md", to: path.join(distDir, "README.md")},
+                {
+                    from: "./package.server.json",
+                    to: path.join(distDir, "package.json"),
+                },
+                {
+                    from: "./README.md",
+                    to: path.join(distDir, "README.md"),
+                },
             ],
         }),
     ],


### PR DESCRIPTION
because of this, `icon-tasm-dark.svg` was not copied into the final bundle.