### PR TITLE
fix(tolk/type-inference): correctly infer return type of function with several return with boolean literals

### DIFF
--- a/server/src/e2e/tolk/testcases/inlay-hints/auto-return-type.test
+++ b/server/src/e2e/tolk/testcases/inlay-hints/auto-return-type.test
@@ -184,3 +184,66 @@ fun some()/* : [int, bool, int] */ {
 fun test()/* : void */ {
     val res/* : [int, bool, int] */ = some();
 }
+
+========================================================================
+Function with several boolean return
+========================================================================
+fun some(some: bool) {
+    if (some) { return false; }
+    return true;
+}
+
+fun test() {
+    val res = some();
+}
+------------------------------------------------------------------------
+fun some(some: bool)/* : bool */ {
+    if (some) { return false; }
+    return true;
+}
+
+fun test()/* : void */ {
+    val res/* : bool */ = some();
+}
+
+========================================================================
+Function with several boolean return 2
+========================================================================
+fun some(some: bool) {
+    if (some) { return true; }
+    return true;
+}
+
+fun test() {
+    val res = some();
+}
+------------------------------------------------------------------------
+fun some(some: bool)/* : bool */ {
+    if (some) { return true; }
+    return true;
+}
+
+fun test()/* : void */ {
+    val res/* : bool */ = some();
+}
+
+========================================================================
+Function with several boolean return 3
+========================================================================
+fun some(some: bool) {
+    if (some) { return false; }
+    return false;
+}
+
+fun test() {
+    val res = some();
+}
+------------------------------------------------------------------------
+fun some(some: bool)/* : bool */ {
+    if (some) { return false; }
+    return false;
+}
+
+fun test()/* : void */ {
+    val res/* : bool */ = some();
+}

--- a/server/src/languages/tolk/types/ty.ts
+++ b/server/src/languages/tolk/types/ty.ts
@@ -783,6 +783,16 @@ export function joinTypes(left: Ty, right: Ty): Ty {
     if (right instanceof NeverTy) return left
     if (right instanceof NullTy) return UnionTy.create([left, right])
 
+    if (left instanceof BoolTy && left.value && right instanceof BoolTy && right.value) {
+        return BoolTy.TRUE // true & true => true
+    }
+    if (left instanceof BoolTy && !left.value && right instanceof BoolTy && !right.value) {
+        return BoolTy.FALSE // false & false => false
+    }
+    if (left instanceof BoolTy && right instanceof BoolTy) {
+        return BoolTy.BOOL // true & false => bool
+    }
+
     if (
         left instanceof TensorTy &&
         right instanceof TensorTy &&


### PR DESCRIPTION

Fixes #86