### PR TITLE
feat(vscode): `TON` extensions to the conflicting

### DIFF
--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -815,7 +815,9 @@ function registerBocWatcher(bocDecompilerProvider: BocDecompilerProvider): FileS
 async function checkConflictingExtensions(): Promise<void> {
     const conflictingExtensions = [
         {id: "dotcypress.language-fift", name: "Fift"},
-        {id: "tonwhales.func-vscode", name: "FunC"},
+        {id: "tonwhales.func-vscode", name: "FunC Language Support"},
+        {id: "raiym.func", name: "FunC"},
+        {id: "natiiix.func-language-support", name: "FunC Language Support"},
         {id: "ton-core.tolk-vscode", name: "Tolk"},
         {id: "krigga.tvm-debugger", name: "TVM Debugger"},
     ]


### PR DESCRIPTION
After we oust the others from the top, it will be possible to remove

<img width="313" height="304" alt="Screenshot 2025-10-04 at 19 56 09" src="https://github.com/user-attachments/assets/87036b39-ad64-4027-9cd5-113a810f836a" />


<img width="310" height="376" alt="Screenshot 2025-10-04 at 20 35 47" src="https://github.com/user-attachments/assets/e3920a36-b0f4-40ed-bbd3-7a44a5647295" />


<img width="310" height="450" alt="Screenshot 2025-10-04 at 20 36 39" src="https://github.com/user-attachments/assets/c139bfa6-b698-4744-b2e3-91eba691c1a1" />

