### PR TITLE
feat(indexing): check that stdlib can be read

### DIFF
--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -72,6 +72,10 @@ Also, you can view extension logs directly in VS Code:
 
 These logs are helpful when reporting issues on GitHub.
 
+### Can't access the Tolk standard library folder
+
+TODO
+
 ## Reporting Issues
 
 If you encounter an issue not covered here:

--- a/server/src/indexing/indexing.ts
+++ b/server/src/indexing/indexing.ts
@@ -2,6 +2,8 @@ import {fileURLToPath} from "node:url"
 
 import * as path from "node:path"
 
+import * as fs from "node:fs"
+
 import {glob} from "glob"
 
 import {filePathToUri} from "@server/files"
@@ -40,6 +42,10 @@ export abstract class IndexingRoot {
             ignore: ignore,
         })
         if (files.length === 0) {
+            if (!this.checkReadAccess(this.root)) {
+                console.warn(`Can't access ${this.root}`)
+            }
+
             console.warn(`No file to index in ${this.root}`)
         }
         for (const filePath of files) {
@@ -47,6 +53,15 @@ export abstract class IndexingRoot {
             const absPath = path.join(rootDir, filePath)
             const uri = filePathToUri(absPath)
             await this.onFile(uri)
+        }
+    }
+
+    private checkReadAccess(path: string): boolean {
+        try {
+            fs.accessSync(path, fs.constants.R_OK)
+            return true
+        } catch {
+            return false
         }
     }
 

--- a/server/src/indexing/indexing.ts
+++ b/server/src/indexing/indexing.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs"
 import {glob} from "glob"
 
 import {filePathToUri} from "@server/files"
-import {showErrorMessage} from "@server/utils/notify"
+import {showErrorMessage, troubleshootingLink} from "@server/utils/notify"
 
 export enum IndexingRootKind {
     Stdlib = "stdlib",
@@ -44,7 +44,8 @@ export abstract class IndexingRoot {
         })
         if (files.length === 0) {
             if (!this.checkReadAccess(this.root)) {
-                const message = `Can't access the '${this.root}' folder in the Tolk standard library.\n`
+                const see = troubleshootingLink("cant-access-the-tolk-standard-library-folder")
+                const message = `Can't access the '${this.root}' folder in the Tolk standard library.\nSee: ${see}`
 
                 showErrorMessage(message)
                 console.error(message)

--- a/server/src/indexing/indexing.ts
+++ b/server/src/indexing/indexing.ts
@@ -44,7 +44,7 @@ export abstract class IndexingRoot {
         })
         if (files.length === 0) {
             if (!this.checkReadAccess(this.root)) {
-                const message = `Can't access ${this.root}`
+                const message = `Can't access the '${this.root}' folder in the Tolk standard library.\n`
 
                 showErrorMessage(message)
                 console.error(message)

--- a/server/src/indexing/indexing.ts
+++ b/server/src/indexing/indexing.ts
@@ -7,6 +7,7 @@ import * as fs from "node:fs"
 import {glob} from "glob"
 
 import {filePathToUri} from "@server/files"
+import {showErrorMessage} from "@server/utils/notify"
 
 export enum IndexingRootKind {
     Stdlib = "stdlib",
@@ -43,7 +44,10 @@ export abstract class IndexingRoot {
         })
         if (files.length === 0) {
             if (!this.checkReadAccess(this.root)) {
-                console.warn(`Can't access ${this.root}`)
+                const message = `Can't access ${this.root}`
+
+                showErrorMessage(message)
+                console.error(message)
             }
 
             console.warn(`No file to index in ${this.root}`)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -135,6 +135,8 @@ import {collectFuncCodeLenses} from "@server/languages/func/lens"
 import {collectFiftCodeLenses} from "@server/languages/fift/lens"
 import {contractAbi} from "@server/languages/tolk/lang/abi/compute"
 
+import {showErrorMessage} from "@server/utils/notify"
+
 import {initParser} from "./parser"
 import {DocumentStore} from "./document-store"
 import {connection} from "./connection"
@@ -228,13 +230,6 @@ async function handleFileOpen(
     if (isTlbFile(uri, event)) {
         await findTlbFile(uri)
     }
-}
-
-const showErrorMessage = (msg: string): void => {
-    void connection.sendNotification(lsp.ShowMessageNotification.type, {
-        type: lsp.MessageType.Error,
-        message: msg,
-    })
 }
 
 async function findTolkStdlib(settings: ServerSettings, rootDir: string): Promise<string | null> {

--- a/server/src/utils/notify.ts
+++ b/server/src/utils/notify.ts
@@ -1,0 +1,10 @@
+import * as lsp from "vscode-languageserver"
+
+import {connection} from "@server/connection"
+
+export const showErrorMessage = (msg: string): void => {
+    void connection.sendNotification(lsp.ShowMessageNotification.type, {
+        type: lsp.MessageType.Error,
+        message: msg,
+    })
+}

--- a/server/src/utils/notify.ts
+++ b/server/src/utils/notify.ts
@@ -8,3 +8,14 @@ export const showErrorMessage = (msg: string): void => {
         message: msg,
     })
 }
+
+export const troubleshootingLink = (section?: string): string => {
+    const troubleshootingDocsLink =
+        "https://github.com/ton-blockchain/ton-language-server/blob/main/docs/manual/troubleshooting.md"
+
+    if (section == undefined) {
+        return `${troubleshootingDocsLink}#${section}`
+    }
+
+    return troubleshootingDocsLink
+}


### PR DESCRIPTION
If you revoke read permissions for the stdlib folder, it will be impossible to know.
I added a check and a notification that it is impossible to read from the specified path.

fix: #201 