### PR TITLE
fix: language IDs in `activationEvents`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "onLanguage:tolk",
         "onLanguage:func",
         "onLanguage:tasm",
-        "onLanguage:fif",
+        "onLanguage:fift",
+        "onLanguage:boc",
         "onLanguage:tlb"
     ],
     "categories": [


### PR DESCRIPTION
In general, after `1.74`, the `onLanguage` activator is called implicitly for languages, so it might be worth removing it altogether. However, to do this, the requirement must be raised to `^1.74.0`, and currently the project is at `^1.63.0`.

Read about it: https://code.visualstudio.com/updates/v1_74#_implicit-activation-events-for-declared-extension-contributions